### PR TITLE
Chore/small changes to wav2vec2 finetuning

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -51,9 +51,9 @@ learning_rate: 3e-5
 adam_first_momentum: 0.9
 adam_second_momentum: 0.98
 total_batch_size: 256
-per_device_batch_size: 16
-max_steps: 50_000
-warmup_steps: 1_000
+per_device_batch_size: 64
+max_steps: 120_000
+warmup_steps: 10_000
 logging_steps: 10
 eval_steps: 100
 save_steps: 100

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -15,7 +15,7 @@ dirs:
 seed: 4242
 
 # Dataset parameters
-characters_to_keep: 'abcdefghijklmnopqrstuvwxyzæøå0123456789éü '
+characters_to_keep: 'abcdefghijklmnopqrstuvwxyzæøå0123456789éü'
 max_seconds_per_example: 10
 dataloader_num_workers: 8
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -47,13 +47,13 @@ ignore_data_skip: false
 save_total_limit: 2
 
 # Optimisation parameters
-learning_rate: 3e-5
+learning_rate: 1e-4
 adam_first_momentum: 0.9
 adam_second_momentum: 0.98
 total_batch_size: 256
-per_device_batch_size: 64
-max_steps: 120_000
-warmup_steps: 10_000
+per_device_batch_size: 16
+max_steps: 10_000
+warmup_steps: 1_000
 logging_steps: 10
 eval_steps: 100
 save_steps: 100

--- a/config/model/test_wav2vec2.yaml
+++ b/config/model/test_wav2vec2.yaml
@@ -9,16 +9,17 @@ clean_dataset: true
 # Model hyperparameters
 sampling_rate: 16_000
 activation_dropout: 0.1
-attention_dropout: 0.1
-hidden_dropout: 0.1
-feat_proj_dropout: 0.1
-final_dropout: 0.1
-mask_time_prob: 0.075
+attention_dropout: 0.0
+hidden_dropout: 0.0
+feat_proj_dropout: 0.0
+feat_quantizer_dropout: 0.0
+final_dropout: 0.0
+mask_time_prob: 0.5
 mask_time_length: 10
-mask_feature_prob: 0.075
-mask_feature_length: 10
-layerdrop: 0.0  # NOTE: This parameter cannot be used in a multi-gpu setting!
-ctc_loss_reduction: sum
+mask_feature_prob: 0.5
+mask_feature_length: 64
+layerdrop: 0.1  # NOTE: This will automatically be set to 0 in a multi-gpu setting
+ctc_loss_reduction: mean
 
 # Decoder hyperparameters
 language_model_decoder: null

--- a/config/model/wav2vec2.yaml
+++ b/config/model/wav2vec2.yaml
@@ -18,7 +18,7 @@ mask_time_prob: 0.3
 mask_time_length: 10
 mask_feature_prob: 0.3
 mask_feature_length: 64
-layerdrop: 0.1  # This will automatically be set to 0 in a multi-gpu setting
+layerdrop: 0.1  # NOTE: This will automatically be set to 0 in a multi-gpu setting
 ctc_loss_reduction: mean
 
 # Decoder hyperparameters

--- a/config/model/wav2vec2.yaml
+++ b/config/model/wav2vec2.yaml
@@ -14,12 +14,12 @@ hidden_dropout: 0.0
 feat_proj_dropout: 0.0
 feat_quantizer_dropout: 0.0
 final_dropout: 0.0
-mask_time_prob: 0.3
+mask_time_prob: 0.5
 mask_time_length: 10
-mask_feature_prob: 0.3
+mask_feature_prob: 0.5
 mask_feature_length: 64
 layerdrop: 0.1  # NOTE: This will automatically be set to 0 in a multi-gpu setting
-ctc_loss_reduction: mean
+ctc_loss_reduction: sum
 
 # Decoder hyperparameters
 language_model_decoder: ngram

--- a/config/model/wav2vec2.yaml
+++ b/config/model/wav2vec2.yaml
@@ -14,9 +14,9 @@ hidden_dropout: 0.0
 feat_proj_dropout: 0.0
 feat_quantizer_dropout: 0.0
 final_dropout: 0.0
-mask_time_prob: 0.5
+mask_time_prob: 0.3
 mask_time_length: 10
-mask_feature_prob: 0.5
+mask_feature_prob: 0.3
 mask_feature_length: 64
 layerdrop: 0.1  # This will automatically be set to 0 in a multi-gpu setting
 ctc_loss_reduction: mean

--- a/src/coral_models/compute_metrics.py
+++ b/src/coral_models/compute_metrics.py
@@ -40,7 +40,12 @@ def compute_wer_metrics(pred: EvalPrediction, processor: Processor) -> dict[str,
         if predictions.dtype == np.int_:
             vocab_size = tokenizer.get_vocab()
             mismatch_dim = len(vocab_size) - predictions.shape[-1]
-            predictions = np.pad(predictions, ((0, 0), (0, 0), (0, mismatch_dim)))
+            predictions = np.pad(
+                array=predictions,
+                pad_width=((0, 0), (0, 0), (0, mismatch_dim)),
+                mode="constant",
+                constant_values=pad_token,
+            )
             predictions_str = tokenizer.batch_decode(sequences=predictions)
 
         # Otherwise, if we are not using a language model, we need to convert the

--- a/src/coral_models/compute_metrics.py
+++ b/src/coral_models/compute_metrics.py
@@ -67,7 +67,7 @@ def compute_wer_metrics(pred: EvalPrediction, processor: Processor) -> dict[str,
     # Decode the ground truth labels
     labels_str = tokenizer.batch_decode(sequences=labels, group_tokens=False)
 
-    # TEMP: Log both the predictions and the ground truth labels
+    # Log both the predictions and the ground truth labels
     is_main_process = os.getenv("RANK", "0") == "0"
     if is_main_process:
         random_idx = np.random.randint(0, len(predictions_str))

--- a/src/coral_models/compute_metrics.py
+++ b/src/coral_models/compute_metrics.py
@@ -41,18 +41,16 @@ def compute_wer_metrics(pred: EvalPrediction, processor: Processor) -> dict[str,
             vocab_size = tokenizer.get_vocab()
             mismatch_dim = len(vocab_size) - predictions.shape[-1]
             predictions = np.pad(predictions, ((0, 0), (0, 0), (0, mismatch_dim)))
-            predictions_str = tokenizer.batch_decode(
-                sequences=predictions, skip_special_tokens=True
-            )
+            predictions_str = tokenizer.batch_decode(sequences=predictions)
 
         # Otherwise, if we are not using a language model, we need to convert the
         # logits to token IDs and then decode the token IDs to get the predicted string
         else:
             pred_ids: NDArray[np.int_] = np.argmax(predictions, axis=-1)
-            predictions_str = tokenizer.batch_decode(pred_ids, skip_special_tokens=True)
+            predictions_str = tokenizer.batch_decode(pred_ids)
 
     elif len(predictions.shape) == 2 and predictions.dtype == np.int_:
-        predictions_str = tokenizer.batch_decode(predictions, skip_special_tokens=True)
+        predictions_str = tokenizer.batch_decode(predictions)
 
     else:
         raise ValueError(
@@ -67,9 +65,7 @@ def compute_wer_metrics(pred: EvalPrediction, processor: Processor) -> dict[str,
     labels[labels == -100] = pad_token
 
     # Decode the ground truth labels
-    labels_str = tokenizer.batch_decode(
-        sequences=labels, skip_special_tokens=True, group_tokens=False
-    )
+    labels_str = tokenizer.batch_decode(sequences=labels, group_tokens=False)
 
     # TEMP: Log both the predictions and the ground truth labels
     is_main_process = os.getenv("RANK", "0") == "0"

--- a/src/coral_models/compute_metrics.py
+++ b/src/coral_models/compute_metrics.py
@@ -51,11 +51,16 @@ def compute_wer_metrics(pred: EvalPrediction, processor: Processor) -> dict[str,
         # Otherwise, if we are not using a language model, we need to convert the
         # logits to token IDs and then decode the token IDs to get the predicted string
         else:
+            # If all the logits are -100 for a token, then we set the logit for the
+            # padding token for that token to 0. This is to ensure that this token gets
+            # decoded to a padding token, and are therefore ignored
+            predictions[np.all(predictions == -100, axis=-1), pad_token] = 0
+
             pred_ids: NDArray[np.int_] = np.argmax(predictions, axis=-1)
             predictions_str = tokenizer.batch_decode(pred_ids)
 
     elif len(predictions.shape) == 2 and predictions.dtype == np.int_:
-        predictions_str = tokenizer.batch_decode(predictions)
+        predictions_str = tokenizer.batch_decode(sequences=predictions)
 
     else:
         raise ValueError(

--- a/src/coral_models/compute_metrics.py
+++ b/src/coral_models/compute_metrics.py
@@ -42,7 +42,7 @@ def compute_wer_metrics(pred: EvalPrediction, processor: Processor) -> dict[str,
             mismatch_dim = len(vocab_size) - predictions.shape[-1]
             predictions = np.pad(predictions, ((0, 0), (0, 0), (0, mismatch_dim)))
             predictions_str = tokenizer.batch_decode(
-                predictions, skip_special_tokens=True
+                sequences=predictions, skip_special_tokens=True
             )
 
         # Otherwise, if we are not using a language model, we need to convert the

--- a/src/coral_models/data.py
+++ b/src/coral_models/data.py
@@ -281,7 +281,7 @@ def clean_dataset(
     # transcriptions, as they do not have an influence on the pronunciation of the
     # words.
     non_standard_characters_regex = re.compile(
-        f"[^{re.escape(cfg.characters_to_keep + ' ')}]"
+        f"[^{re.escape(cfg.characters_to_keep + ' |')}]"
     )
 
     mapped = dataset.map(

--- a/src/coral_models/data.py
+++ b/src/coral_models/data.py
@@ -281,7 +281,7 @@ def clean_dataset(
     # transcriptions, as they do not have an influence on the pronunciation of the
     # words.
     non_standard_characters_regex = re.compile(
-        f"[^{re.escape(cfg.characters_to_keep)}]"
+        f"[^{re.escape(cfg.characters_to_keep + ' ')}]"
     )
 
     mapped = dataset.map(

--- a/src/coral_models/finetune.py
+++ b/src/coral_models/finetune.py
@@ -70,6 +70,7 @@ def finetune(cfg: DictConfig) -> None:
 
     model_setup: ModelSetup = load_model_setup(cfg)
     processor = model_setup.load_processor()
+    breakpoint()
     processor.save_pretrained(cfg.model_dir)
     model = model_setup.load_model()
     dataset = load_data(cfg)

--- a/src/coral_models/finetune.py
+++ b/src/coral_models/finetune.py
@@ -70,7 +70,6 @@ def finetune(cfg: DictConfig) -> None:
 
     model_setup: ModelSetup = load_model_setup(cfg)
     processor = model_setup.load_processor()
-    breakpoint()
     processor.save_pretrained(cfg.model_dir)
     model = model_setup.load_model()
     dataset = load_data(cfg)

--- a/src/coral_models/wav2vec2.py
+++ b/src/coral_models/wav2vec2.py
@@ -128,8 +128,8 @@ class Wav2Vec2ModelSetup:
                 dump_vocabulary(self.cfg)
                 tokenizer: Wav2Vec2CTCTokenizer = Wav2Vec2CTCTokenizer.from_pretrained(
                     self.cfg.model_dir,
-                    unk_token="<unk>",
                     pad_token="<pad>",
+                    unk_token="<unk>",
                     bos_token="<s>",
                     eos_token="</s>",
                     word_delimiter_token="|",
@@ -310,8 +310,6 @@ def dump_vocabulary(cfg: DictConfig) -> None:
 
     # Build vocabulary
     vocab = {char: idx for idx, char in enumerate(unique_characters)}
-    for tok in ["<unk>", "<pad>", "<s>", "</s>"]:
-        vocab[tok] = len(vocab)
 
     # Dump the vocabulary to a json file
     model_dir = Path(cfg.model_dir)

--- a/src/coral_models/wav2vec2.py
+++ b/src/coral_models/wav2vec2.py
@@ -133,11 +133,12 @@ class Wav2Vec2ModelSetup:
                 )
                 break
             except json.decoder.JSONDecodeError:
-                process_id = os.getenv("RANK", 0)
-                logger.warning(
-                    f"JSONDecodeError while loading tokenizer on process {process_id}. "
-                    "Retrying in a second."
-                )
+                log_message = "JSONDecodeError while loading tokenizer"
+                process_id = os.getenv("RANK")
+                if process_id is not None:
+                    log_message += f" in process {process_id}"
+                log_message += ". Retrying in a second."
+                logger.warning(log_message)
                 time.sleep(1)
 
         # Set the `model_max_length` attribute of the tokenizer, if it hasn't been set,

--- a/src/coral_models/wav2vec2.py
+++ b/src/coral_models/wav2vec2.py
@@ -62,8 +62,8 @@ class DataCollatorCTCWithPadding(DataCollatorMixin):
     """
 
     processor: Wav2Vec2Processor
-    padding: bool | str
     max_seconds_per_example: float
+    padding: bool | str
     return_tensors: str = "pt"
 
     def torch_call(self, features: list[dict]) -> BatchFeature:

--- a/src/coral_models/wav2vec2.py
+++ b/src/coral_models/wav2vec2.py
@@ -129,7 +129,8 @@ class Wav2Vec2ModelSetup:
                     pad_token="<pad>",
                     bos_token="<s>",
                     eos_token="</s>",
-                    word_delimiter_token=" ",
+                    word_delimiter_token="|",
+                    replace_word_delimiter_char=" ",
                 )
                 break
             except json.decoder.JSONDecodeError:
@@ -156,6 +157,7 @@ class Wav2Vec2ModelSetup:
         self.processor = Wav2Vec2Processor(
             feature_extractor=extractor, tokenizer=tokenizer
         )
+
         return self.processor
 
     def load_model(self) -> Wav2Vec2ForCTC:
@@ -180,7 +182,7 @@ class Wav2Vec2ModelSetup:
                 vocab_size=len(self.processor.tokenizer.get_vocab()),
                 ctc_zero_infinity=True,
             )
-            assert isinstance(model, Wav2Vec2ForCTC)
+        assert isinstance(model, Wav2Vec2ForCTC)
 
         if self.cfg.model.freeze_feature_encoder:
             for param in model.wav2vec2.parameters():

--- a/src/coral_models/whisper.py
+++ b/src/coral_models/whisper.py
@@ -77,15 +77,23 @@ class DataCollatorSpeechSeq2SeqWithPadding(DataCollatorMixin):
             raise ValueError(
                 "Features must contain either 'input_features' or 'audio' key."
             )
-        batch = self.processor.feature_extractor.pad(
-            audio_features, return_tensors="pt"
+        batch = self.processor.pad(
+            audio_features,
+            padding=self.padding,
+            return_tensors=self.return_tensors,
+            max_length=16_000 * self.max_seconds_per_example,
         )
 
         # Get the tokenized label sequences
         label_features = [{"input_ids": feature["labels"]} for feature in features]
 
         # Pad the labels to max length
-        labels_batch = self.processor.tokenizer.pad(label_features, return_tensors="pt")
+        labels_batch = self.processor.pad(
+            labels=label_features,
+            padding=self.padding,
+            return_tensors=self.return_tensors,
+            max_length=512,
+        )
 
         # replace padding with -100 to ignore loss correctly
         labels = labels_batch["input_ids"].masked_fill(

--- a/src/coral_models/whisper.py
+++ b/src/coral_models/whisper.py
@@ -36,6 +36,8 @@ class DataCollatorSpeechSeq2SeqWithPadding(DataCollatorMixin):
     Args:
         processor (WhisperProcessor)
             The processor used for proccessing the data.
+        max_seconds_per_example (float):
+            The maximum number of seconds per example.
         padding (bool, str or PaddingStrategy, optional):
             Select a strategy to pad the returned sequences (according to the model's
             padding side and padding index) among:
@@ -53,6 +55,7 @@ class DataCollatorSpeechSeq2SeqWithPadding(DataCollatorMixin):
     """
 
     processor: WhisperProcessor
+    max_seconds_per_example: float
     padding: bool | str = True
     return_tensors: str = "pt"
 

--- a/src/coral_models/whisper.py
+++ b/src/coral_models/whisper.py
@@ -92,7 +92,7 @@ class DataCollatorSpeechSeq2SeqWithPadding(DataCollatorMixin):
 
         # Pad the labels to max length
         labels_batch = self.processor.tokenizer.pad(
-            labels=label_features,
+            label_features,
             padding=self.padding,
             return_tensors=self.return_tensors,
             max_length=512,

--- a/src/coral_models/whisper.py
+++ b/src/coral_models/whisper.py
@@ -174,7 +174,7 @@ class WhisperModelSetup:
     def load_data_collator(self) -> DataCollatorSpeechSeq2SeqWithPadding:
         return DataCollatorSpeechSeq2SeqWithPadding(
             processor=self.processor,
-            max_seconds_per_example=self.cfg.data.max_seconds_per_example,
+            max_seconds_per_example=self.cfg.max_seconds_per_example,
             padding=self.cfg.padding,
         )
 

--- a/src/coral_models/whisper.py
+++ b/src/coral_models/whisper.py
@@ -77,7 +77,7 @@ class DataCollatorSpeechSeq2SeqWithPadding(DataCollatorMixin):
             raise ValueError(
                 "Features must contain either 'input_features' or 'audio' key."
             )
-        batch = self.processor.pad(
+        batch = self.processor.feature_extractor.pad(
             audio_features,
             padding=self.padding,
             return_tensors=self.return_tensors,
@@ -88,7 +88,7 @@ class DataCollatorSpeechSeq2SeqWithPadding(DataCollatorMixin):
         label_features = [{"input_ids": feature["labels"]} for feature in features]
 
         # Pad the labels to max length
-        labels_batch = self.processor.pad(
+        labels_batch = self.processor.tokenizer.pad(
             labels=label_features,
             padding=self.padding,
             return_tensors=self.return_tensors,

--- a/src/coral_models/whisper.py
+++ b/src/coral_models/whisper.py
@@ -173,7 +173,9 @@ class WhisperModelSetup:
 
     def load_data_collator(self) -> DataCollatorSpeechSeq2SeqWithPadding:
         return DataCollatorSpeechSeq2SeqWithPadding(
-            processor=self.processor, padding=self.cfg.padding
+            processor=self.processor,
+            max_seconds_per_example=self.cfg.data.max_seconds_per_example,
+            padding=self.cfg.padding,
         )
 
     def load_trainer_class(self) -> Type[Trainer]:


### PR DESCRIPTION
This PR implements the following:

1. Fixes an error related to decoding, where duplicate characters would be collapsed (e.g., "hotellet" -> "hotelet"). This was due to the removal of pad tokens during decoding, which we shouldn't do, since they act as CTC boundaries.
2. Small changes (config changes, some logging)

With this setup, we get quite close to reproducing the original setup. More precisely, we arrive at around 16 WER on Common Voice 9.0, which is not too far away from the SOTA 11 WER, and seems to mainly be due to overfitting. Here are the training plots:
![W B Chart 05_12_2023, 13_11_29](https://github.com/alexandrainst/coral_models/assets/47701536/d7d91e8f-0341-4eee-85ae-7ee3a40aadd5)
![W B Chart 05_12_2023, 13_11_43](https://github.com/alexandrainst/coral_models/assets/47701536/a5c60ef1-31ed-4b46-8ec6-6b4b59f2342b)
![W B Chart 05_12_2023, 13_12_19](https://github.com/alexandrainst/coral_models/assets/47701536/9b7dc39a-0dc5-404c-963d-13b0520633fe)

Notably, I sample NST-da and CV9.0 _equally_, so we go through _a lot_ of Common Voice samples in 120k steps! The sampling ratios should probably be changed, and the masking probabilities should probably be increased.

In any case, I think we're probably close enough to a reproduction to trust the framework and start training models on more data, in any case.

Oh, and I tried freezing the parameters, and also to increase the warmup time. Freezing the parameters didn't help at all, and the increased warmup time _might_ have helped a little bit.