### PR TITLE
fix: size of empty files

### DIFF
--- a/src/coral_models/prepare_raw_data.py
+++ b/src/coral_models/prepare_raw_data.py
@@ -350,7 +350,7 @@ def prepare_raw_data(
 
         # Check if the file is empty, and if it is, remove it from the dataframe
         # and continue to the next file
-        if filename.stat().st_size < 200000:  # Any file smaller than this is empty
+        if filename.stat().st_size < 10000:  # Any file smaller than this is empty
             rows_to_remove.append(row_i)
             continue
 


### PR DESCRIPTION
The empty _processed_ files are <200kB while the unprocessed files, which are those we are checking, are <10kB... Had a mini heart attack when it seemed like we had only managed to collect 15 hours throughout all of November and December... 